### PR TITLE
Changed deprecated call 'activationEvents' to 'activationCommands'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": false,
   "description": "Quickly add various OSS licenses to your software using the command palette.",
-  "activationEvents": [
+  "activationCommands": [
     "license:MIT",
     "license:Apache-2․0",
     "license:BSD",


### PR DESCRIPTION
Atom updated its activationEvents call to be activationCommands. Changed package.json accordingly.
